### PR TITLE
fix: pasting of snippets not working

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -531,7 +531,7 @@ public class ContextManager implements IContextManager
         }
 
         // If not a stacktrace, add as string fragment
-        addPasteFragment("Pasted text", submitSummarizeTaskForPaste(clipboardText));
+        addPasteFragment(clipboardText, submitSummarizeTaskForPaste(clipboardText));
         chrome.toolOutput("Clipboard content added as text");
     }
 


### PR DESCRIPTION
It is always only showing "pasted content" as the content.