### PR TITLE
fix: Add asynchronous method for setting auto-context file count

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -942,9 +942,29 @@ public class ContextManager implements IContextManager
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Update auto-context file count on the current executor thread (for background operations)
+     */
     public void setAutoContextFiles(int fileCount)
     {
         pushContext(ctx -> ctx.setAutoContextFiles(fileCount));
+    }
+
+    /**
+     * Asynchronous version of setAutoContextFiles to avoid blocking the UI thread
+     */
+    public Future<?> setAutoContextFilesAsync(int fileCount)
+    {
+        return contextActionExecutor.submit(() -> {
+            try {
+                setAutoContextFiles(fileCount);
+            } catch (CancellationException cex) {
+                chrome.toolOutput("Auto-context update canceled.");
+            } finally {
+                chrome.enableContextActionButtons();
+                chrome.enableUserActionButtons();
+            }
+        });
     }
 
     public List<ChatMessage> getHistoryMessages()

--- a/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
@@ -50,7 +50,7 @@ public class MenuBar {
 
             okButton.addActionListener(okEvent -> {
                 var newSize = (int) spinner.getValue();
-                chrome.contextManager.setAutoContextFiles(newSize);
+                chrome.contextManager.setAutoContextFilesAsync(newSize);
                 dialog.dispose();
             });
 


### PR DESCRIPTION
I got an exception changing the autosummaries count when the autosummaries are still in place:

Changed it to follow the worker pattern to not been called from the EDT thread.

```java
Exception in thread "AWT-EventQueue-0" java.lang.UnsupportedOperationException: Never call blocking get() from EDT
        at io.github.jbellis.brokk.AnalyzerWrapper.get(AnalyzerWrapper.java:379)
        at io.github.jbellis.brokk.AnalyzerWrapper.get(AnalyzerWrapper.java:404)
        at io.github.jbellis.brokk.Context.lambda$buildAutoContext$7(Context.java:316)
        at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
        at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
        at com.google.common.collect.CollectSpliterators$FlatMapSpliterator.lambda$forEachRemaining$1(CollectSpliterators.java:377)
        at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
        at com.google.common.collect.CollectSpliterators$FlatMapSpliterator.forEachRemaining(CollectSpliterators.java:373)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at io.github.jbellis.brokk.Context.buildAutoContext(Context.java:317)
        at io.github.jbellis.brokk.Context.setAutoContextFiles(Context.java:275)
        at io.github.jbellis.brokk.ContextManager.lambda$setAutoContextFiles$30(ContextManager.java:947)
        at io.github.jbellis.brokk.ContextManager.pushContext(ContextManager.java:1050)
        at io.github.jbellis.brokk.ContextManager.setAutoContextFiles(ContextManager.java:947)
        at io.github.jbellis.brokk.gui.MenuBar.lambda$buildMenuBar$1(MenuBar.java:53)
        at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
        at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2314)
        at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:407)
        at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
        at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
        at java.desktop/java.awt.Component.processMouseEvent(Component.java:6621)
        at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3398)
        at java.desktop/java.awt.Component.processEvent(Component.java:6386)
        at java.desktop/java.awt.Container.processEvent(Container.java:2266)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4996)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
        at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
        at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:117)
        at java.desktop/java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:191)
        at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:236)
        at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:234)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
        at java.desktop/java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:234)
        at java.desktop/java.awt.Dialog.show(Dialog.java:1079)
        at java.desktop/java.awt.Component.show(Component.java:1728)
        at java.desktop/java.awt.Component.setVisible(Component.java:1675)
        at java.desktop/java.awt.Window.setVisible(Window.java:1036)
        at java.desktop/java.awt.Dialog.setVisible(Dialog.java:1015)
        at io.github.jbellis.brokk.gui.MenuBar.lambda$buildMenuBar$4(MenuBar.java:72)
        at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
        at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2314)
        at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:407)
        at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
        at java.desktop/javax.swing.AbstractButton.doClick(AbstractButton.java:374)
        at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:1029)
        at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI$Handler.menuDragMouseReleased(BasicMenuItemUI.java:1141)
        at java.desktop/javax.swing.JMenuItem.fireMenuDragMouseReleased(JMenuItem.java:587)
        at java.desktop/javax.swing.JMenuItem.processMenuDragMouseEvent(JMenuItem.java:484)
        at java.desktop/javax.swing.JMenuItem.processMouseEvent(JMenuItem.java:429)
        at java.desktop/javax.swing.MenuSelectionManager.processMouseEvent(MenuSelectionManager.java:347)
        at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:1075)
        at java.desktop/java.awt.Component.processMouseEvent(Component.java:6621)
        at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3398)
        at java.desktop/java.awt.Component.processEvent(Component.java:6386)
        at java.desktop/java.awt.Container.processEvent(Container.java:2266)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4996)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
        at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
        at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)

```