### PR TITLE
feat: Add light and dark theme support

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/Project.java
+++ b/src/main/java/io/github/jbellis/brokk/Project.java
@@ -403,6 +403,23 @@ public class Project implements IProject {
         }
     }
     
+    /**
+     * Gets the current UI theme (dark or light)
+     * @return "dark" or "light" (defaults to "dark" if not set)
+     */
+    public String getTheme() {
+        return workspaceProps.getProperty("theme", "light");
+    }
+    
+    /**
+     * Sets the UI theme
+     * @param theme "dark" or "light"
+     */
+    public void setTheme(String theme) {
+        workspaceProps.setProperty("theme", theme);
+        saveWorkspaceProperties();
+    }
+    
     public void saveLlmKeys(Map<String, String> keys) {
         var keysPath = getLlmKeysPath();
 

--- a/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
@@ -1,0 +1,165 @@
+package io.github.jbellis.brokk.gui;
+
+import io.github.jbellis.brokk.Project;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rsyntaxtextarea.Theme;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Manages UI theme settings and application across the application.
+ */
+public class GuiTheme {
+    private static final Logger logger = LogManager.getLogger(GuiTheme.class);
+    
+    public static final String THEME_DARK = "dark";
+    public static final String THEME_LIGHT = "light";
+    
+    private final Project project;
+    private final JFrame frame;
+    private final JScrollPane mainScrollPane;
+    private final Chrome chrome;
+    
+    /**
+     * Creates a new theme manager
+     * 
+     * @param project The current project (for persistence)
+     * @param frame The main application frame
+     * @param mainScrollPane The main scroll pane for LLM output
+     * @param chrome The Chrome instance for UI feedback
+     */
+    public GuiTheme(Project project, JFrame frame, JScrollPane mainScrollPane, Chrome chrome) {
+        this.project = project;
+        this.frame = frame;
+        this.mainScrollPane = mainScrollPane;
+        this.chrome = chrome;
+    }
+    
+    /**
+     * Applies the current theme to the application
+     * 
+     * @param isDark true for dark theme, false for light theme
+     */
+    public void applyTheme(boolean isDark) {
+        String themeName = isDark ? THEME_DARK : THEME_LIGHT;
+        try {
+            if (isDark) {
+                com.formdev.flatlaf.FlatDarkLaf.setup();
+            } else {
+                com.formdev.flatlaf.FlatLightLaf.setup();
+            }
+            
+            // Save preference if project exists
+            if (project != null) {
+                project.setTheme(themeName);
+            }
+            
+            // Apply theme to RSyntaxTextArea components
+            applyRSyntaxTheme(themeName);
+            
+            // Update the UI
+            SwingUtilities.updateComponentTreeUI(frame);
+            
+            // Make sure scroll panes update properly
+            if (mainScrollPane != null) {
+                mainScrollPane.revalidate();
+            }
+            
+            // Notify user
+            chrome.toolOutput("Switched to " + (isDark ? "dark" : "light") + " theme");
+        } catch (Exception e) {
+            logger.error("Failed to switch theme", e);
+            chrome.toolError("Failed to switch theme: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Applies the appropriate theme to all RSyntaxTextArea components
+     * @param themeName "dark" or "light"
+     */
+    public void applyRSyntaxTheme(String themeName) {
+        String themeResource = "/org/fife/ui/rsyntaxtextarea/themes/" +
+                              (themeName.equals(THEME_DARK) ? "dark.xml" : "default.xml");
+        try {
+            var theme = Theme.load(getClass().getResourceAsStream(themeResource));
+            
+            // Apply to all RSyntaxTextArea components in open windows
+            for (Window window : Window.getWindows()) {
+                if (window instanceof JFrame) {
+                    applyThemeToFrame((JFrame)window, theme);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not apply " + themeName + " theme to RSyntaxTextArea", e);
+        }
+    }
+    
+    /**
+     * Applies theme to all RSyntaxTextArea components in a frame
+     */
+    private void applyThemeToFrame(JFrame frame, Theme theme) {
+        // Apply to direct components
+        for (Component c : frame.getContentPane().getComponents()) {
+            if (c instanceof RSyntaxTextArea) {
+                theme.apply((RSyntaxTextArea) c);
+            } else if (c instanceof JScrollPane) {
+                Component view = ((JScrollPane) c).getViewport().getView();
+                if (view instanceof RSyntaxTextArea) {
+                    theme.apply((RSyntaxTextArea) view);
+                }
+            } else {
+                // Recursively look for nested components
+                findAndApplyTheme(c, theme);
+            }
+        }
+    }
+    
+    /**
+     * Recursively finds RSyntaxTextArea components and applies theme
+     */
+    private void findAndApplyTheme(Component component, Theme theme) {
+        if (component instanceof RSyntaxTextArea) {
+            theme.apply((RSyntaxTextArea) component);
+        } else if (component instanceof Container) {
+            for (Component child : ((Container) component).getComponents()) {
+                findAndApplyTheme(child, theme);
+            }
+        }
+    }
+    
+    /**
+     * Gets the current theme name
+     * @return The current theme name ("dark" or "light")
+     */
+    public String getCurrentTheme() {
+        return project != null ? project.getTheme() : THEME_LIGHT;
+    }
+    
+    /**
+     * Checks if dark theme is currently active
+     * @return true if dark theme is active
+     */
+    public boolean isDarkTheme() {
+        return THEME_DARK.equalsIgnoreCase(getCurrentTheme());
+    }
+    
+    /**
+     * Applies the current theme to a specific RSyntaxTextArea
+     * @param textArea The text area to apply theme to
+     */
+    public void applyCurrentThemeToComponent(RSyntaxTextArea textArea) {
+        try {
+            String currentTheme = getCurrentTheme();
+            String themeResource = "/org/fife/ui/rsyntaxtextarea/themes/" +
+                                  (currentTheme.equals(THEME_DARK) ? "dark.xml" : "default.xml");
+
+            Theme.load(getClass().getResourceAsStream(themeResource))
+                .apply(textArea);
+        } catch (Exception e) {
+            logger.warn("Could not apply theme to RSyntaxTextArea component", e);
+        }
+    }
+}

--- a/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/MenuBar.java
@@ -159,6 +159,24 @@ public class MenuBar {
         var helpMenu = new JMenu("Help");
         helpMenu.setMnemonic(KeyEvent.VK_H);
 
+        // Theme submenu
+        var themeMenu = new JMenu("Theme");
+        themeMenu.setMnemonic(KeyEvent.VK_T);
+        
+        var lightThemeItem = new JMenuItem("Light");
+        lightThemeItem.addActionListener(e -> chrome.switchTheme(false));
+        lightThemeItem.setToolTipText("Switch to light theme");
+
+        var darkThemeItem = new JMenuItem("Dark");
+        darkThemeItem.addActionListener(e -> chrome.switchTheme(true));
+        darkThemeItem.setToolTipText("Switch to dark theme");
+        
+        themeMenu.add(lightThemeItem);
+        themeMenu.add(darkThemeItem);
+        helpMenu.add(themeMenu);
+        
+        helpMenu.addSeparator();
+        
         var aboutItem = new JMenuItem("About");
         aboutItem.addActionListener(e -> {
             JOptionPane.showMessageDialog(chrome.frame,


### PR DESCRIPTION
- On the fly switch between Bright/Dark Theme.
- Persisted in Project.Properties
- central manager GuiTheme class


![image](https://github.com/user-attachments/assets/acdc35ce-7981-4c49-9090-cb7089453a4f)

![image](https://github.com/user-attachments/assets/4996100a-6769-4afa-9f98-340c8d3292de)
