### PR TITLE
Feat/add history button

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -564,44 +564,8 @@ public class Chrome implements AutoCloseable, IConsoleIO {
                 new EmptyBorder(5, 5, 5, 5)
         ));
         
-        // Create history dropdown button in its own panel for left alignment
-        JPanel historyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        JButton historyButton = new JButton("History ▼");
-        historyButton.setToolTipText("Select an instruction template from history");
-        historyPanel.add(historyButton);
-
-        // Create popup menu with 10 dummy entries with a minimum width
-        JPopupMenu historyMenu = new JPopupMenu();
-        
-        for (int i = 1; i <= 10; i++) {
-            final String templateText = "Template " + i + " content - this is dummy template text for demonstration purposes.";
-            JMenuItem item = new JMenuItem("Template " + i);
-            item.addActionListener(e -> {
-                commandInputField.setText(templateText);
-            });
-            historyMenu.add(item);
-        }
-        
-        // Set minimum width for popup menu after adding items
-        historyMenu.setMinimumSize(new Dimension(300, 0));
-        historyMenu.setPreferredSize(new Dimension(300, historyMenu.getPreferredSize().height));
-
-        // Show popup above the button when clicked
-        historyButton.addActionListener(e -> {
-            // Show the popup menu above the button - calculate correct height
-            // First ensure menu is realized so it has correct dimensions
-            historyMenu.pack();
-            historyMenu.show(historyButton, 0, -historyMenu.getPreferredSize().height);
-        });
-        
-        // Register popup menu with theme manager for theme updates
-        SwingUtilities.invokeLater(() -> {
-            if (themeManager != null) {
-                themeManager.registerPopupMenu(historyMenu);
-            }
-        });
-
-        // Add history button panel at the top of the wrapper
+        // Add history dropdown at the top of the wrapper
+        JPanel historyPanel = buildHistoryDropdown();
         wrapper.add(historyPanel, BorderLayout.NORTH);
 
         commandInputField = new JTextArea(3, 40);
@@ -1468,6 +1432,50 @@ public class Chrome implements AutoCloseable, IConsoleIO {
         return SwingUtil.runOnEDT(() -> (Context) contextHistoryTable.getModel().getValueAt(selected, 1), null);
     }
     
+    /**
+     * Builds the history dropdown panel with template selections
+     * @return A panel containing the history dropdown button
+     */
+    private JPanel buildHistoryDropdown() {
+        JPanel historyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        JButton historyButton = new JButton("History ▼");
+        historyButton.setToolTipText("Select an instruction template from history");
+        historyPanel.add(historyButton);
+
+        // Create popup menu with 10 dummy entries with a minimum width
+        JPopupMenu historyMenu = new JPopupMenu();
+
+        for (int i = 1; i <= 10; i++) {
+            final String templateText = "Template " + i + " content - this is dummy template text for demonstration purposes.";
+            JMenuItem item = new JMenuItem("Template " + i);
+            item.addActionListener(e -> {
+                commandInputField.setText(templateText);
+            });
+            historyMenu.add(item);
+        }
+
+        // Set minimum width for popup menu after adding items
+        historyMenu.setMinimumSize(new Dimension(300, 0));
+        historyMenu.setPreferredSize(new Dimension(300, historyMenu.getPreferredSize().height));
+
+        // Show popup above the button when clicked
+        historyButton.addActionListener(e -> {
+            // Show the popup menu above the button - calculate correct height
+            // First ensure menu is realized so it has correct dimensions
+            historyMenu.pack();
+            historyMenu.show(historyButton, 0, -historyMenu.getPreferredSize().height);
+        });
+
+        // Register popup menu with theme manager for theme updates
+        SwingUtilities.invokeLater(() -> {
+            if (themeManager != null) {
+                themeManager.registerPopupMenu(historyMenu);
+            }
+        });
+
+        return historyPanel;
+    }
+
     private void setInitialHistoryPanelWidth() {
         // Safety checks
         if (historySplitPane == null) {

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -470,16 +470,21 @@ public class Chrome implements AutoCloseable, IConsoleIO {
             private void showContextHistoryPopupMenu(MouseEvent e) {
         int row = contextHistoryTable.rowAtPoint(e.getPoint());
         if (row < 0) return;
-        
+
         // Select the row under the cursor
         contextHistoryTable.setRowSelectionInterval(row, row);
-        
+
         // Create popup menu
         JPopupMenu popup = new JPopupMenu();
         JMenuItem undoToHereItem = new JMenuItem("Undo to here");
         undoToHereItem.addActionListener(event -> restoreContextFromHistory(row));
         popup.add(undoToHereItem);
         
+        // Register popup with theme manager
+        if (themeManager != null) {
+            themeManager.registerPopupMenu(popup);
+        }
+
         // Show popup menu
         popup.show(contextHistoryTable, e.getX(), e.getY());
     }
@@ -587,6 +592,13 @@ public class Chrome implements AutoCloseable, IConsoleIO {
             // First ensure menu is realized so it has correct dimensions
             historyMenu.pack();
             historyMenu.show(historyButton, 0, -historyMenu.getPreferredSize().height);
+        });
+        
+        // Register popup menu with theme manager for theme updates
+        SwingUtilities.invokeLater(() -> {
+            if (themeManager != null) {
+                themeManager.registerPopupMenu(historyMenu);
+            }
         });
 
         // Add history button panel at the top of the wrapper

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -559,28 +559,38 @@ public class Chrome implements AutoCloseable, IConsoleIO {
                 new EmptyBorder(5, 5, 5, 5)
         ));
         
-        // Create template dropdown button
-        JButton templateButton = new JButton("Template ▼");
-        templateButton.setToolTipText("Select an instruction template");
+        // Create history dropdown button in its own panel for left alignment
+        JPanel historyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        JButton historyButton = new JButton("History ▼");
+        historyButton.setToolTipText("Select an instruction template from history");
+        historyPanel.add(historyButton);
+
+        // Create popup menu with 10 dummy entries with a minimum width
+        JPopupMenu historyMenu = new JPopupMenu();
         
-        // Create popup menu with 10 dummy entries
-        JPopupMenu templateMenu = new JPopupMenu();
         for (int i = 1; i <= 10; i++) {
             final String templateText = "Template " + i + " content - this is dummy template text for demonstration purposes.";
             JMenuItem item = new JMenuItem("Template " + i);
             item.addActionListener(e -> {
                 commandInputField.setText(templateText);
             });
-            templateMenu.add(item);
+            historyMenu.add(item);
         }
         
+        // Set minimum width for popup menu after adding items
+        historyMenu.setMinimumSize(new Dimension(300, 0));
+        historyMenu.setPreferredSize(new Dimension(300, historyMenu.getPreferredSize().height));
+
         // Show popup above the button when clicked
-        templateButton.addActionListener(e -> {
-            templateMenu.show(templateButton, 0, -templateMenu.getPreferredSize().height);
+        historyButton.addActionListener(e -> {
+            // Show the popup menu above the button - calculate correct height
+            // First ensure menu is realized so it has correct dimensions
+            historyMenu.pack();
+            historyMenu.show(historyButton, 0, -historyMenu.getPreferredSize().height);
         });
-        
-        // Add template button at the top of the wrapper
-        wrapper.add(templateButton, BorderLayout.NORTH);
+
+        // Add history button panel at the top of the wrapper
+        wrapper.add(historyPanel, BorderLayout.NORTH);
 
         commandInputField = new JTextArea(3, 40);
         commandInputField.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -1484,7 +1484,10 @@ public class Chrome implements AutoCloseable, IConsoleIO {
                 emptyItem.setEnabled(false);
                 historyMenu.add(emptyItem);
             } else {
-                for (String item : historyItems) {
+                // Iterate in reverse order so newest items appear at the bottom of the dropdown
+                // This creates a more natural flow when the dropdown appears above the button
+                for (int i = historyItems.size() - 1; i >= 0; i--) {
+                    String item = historyItems.get(i);
                     // Use static truncation length
                     String displayText = item.length() > TRUNCATION_LENGTH ?
                         item.substring(0, TRUNCATION_LENGTH - 3) + "..." : item;

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -558,6 +558,29 @@ public class Chrome implements AutoCloseable, IConsoleIO {
                 ),
                 new EmptyBorder(5, 5, 5, 5)
         ));
+        
+        // Create template dropdown button
+        JButton templateButton = new JButton("Template ▼");
+        templateButton.setToolTipText("Select an instruction template");
+        
+        // Create popup menu with 10 dummy entries
+        JPopupMenu templateMenu = new JPopupMenu();
+        for (int i = 1; i <= 10; i++) {
+            final String templateText = "Template " + i + " content - this is dummy template text for demonstration purposes.";
+            JMenuItem item = new JMenuItem("Template " + i);
+            item.addActionListener(e -> {
+                commandInputField.setText(templateText);
+            });
+            templateMenu.add(item);
+        }
+        
+        // Show popup above the button when clicked
+        templateButton.addActionListener(e -> {
+            templateMenu.show(templateButton, 0, -templateMenu.getPreferredSize().height);
+        });
+        
+        // Add template button at the top of the wrapper
+        wrapper.add(templateButton, BorderLayout.NORTH);
 
         commandInputField = new JTextArea(3, 40);
         commandInputField.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));

--- a/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/GuiTheme.java
@@ -8,6 +8,8 @@ import org.fife.ui.rsyntaxtextarea.Theme;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Manages UI theme settings and application across the application.
@@ -22,6 +24,9 @@ public class GuiTheme {
     private final JFrame frame;
     private final JScrollPane mainScrollPane;
     private final Chrome chrome;
+    
+    // Track registered popup menus that need theme updates
+    private final List<JPopupMenu> popupMenus = new ArrayList<>();
     
     /**
      * Creates a new theme manager
@@ -65,6 +70,11 @@ public class GuiTheme {
             // Update the UI
             SwingUtilities.updateComponentTreeUI(frame);
             
+            // Update registered popup menus
+            for (JPopupMenu menu : popupMenus) {
+                SwingUtilities.updateComponentTreeUI(menu);
+            }
+
             // Make sure scroll panes update properly
             if (mainScrollPane != null) {
                 mainScrollPane.revalidate();
@@ -148,6 +158,19 @@ public class GuiTheme {
         return THEME_DARK.equalsIgnoreCase(getCurrentTheme());
     }
     
+    /**
+     * Registers a popup menu to receive theme updates
+     * @param menu The popup menu to register
+     */
+    public void registerPopupMenu(JPopupMenu menu) {
+        if (!popupMenus.contains(menu)) {
+            popupMenus.add(menu);
+            
+            // Apply current theme immediately if already initialized
+            SwingUtilities.invokeLater(() -> SwingUtilities.updateComponentTreeUI(menu));
+        }
+    }
+
     /**
      * Applies the current theme to a specific RSyntaxTextArea
      * @param textArea The text area to apply theme to


### PR DESCRIPTION
# Add Command History Feature

## Overview

This PR introduces a command history feature, allowing users to easily recall and reuse previous commands, questions, and code snippets they've entered. This enhances user experience by providing quick access to recent inputs without having to retype them.

![image](https://github.com/user-attachments/assets/3896bce2-a907-4403-87cb-4d07476ed64b)

## Key Changes

### History Storage and Management
- Added methods in `Project.java` to save, load, and manage text history:
  - `saveTextHistory()` - Serializes history items to workspace properties
  - `loadTextHistory()` - Retrieves history items from workspace properties
  - `addToTextHistory()` - Adds new items and maintains maximum history size

### UI Components
- Added a "History ▼" dropdown button above the command input area
- Implemented a dropdown menu that displays the user's command history
- Added truncation for long commands with tooltips to show full text
- Ensured proper theme support for the dropdown menu

### Theme Improvements
- Enhanced `GuiTheme` class to properly manage popup menus
- Added tracking of registered popup menus to ensure consistent theming
- Added support for context history popup theming

### Command Capture
- Modified command execution methods to automatically add inputs to history:
  - Code execution
  - Command runs
  - LLM questions
  - Search queries

## Technical Details
- History is stored as JSON in workspace properties
- Items are displayed newest-to-oldest with the most recent at the bottom
- Menu uses a fixed width (1000px) with text truncation at 100 characters
- Maximum history size is set to 20 items