### PR TITLE
fix: Set reasonable default for vertical split pane

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -292,6 +292,8 @@ public class Chrome implements AutoCloseable, IConsoleIO {
             
         // Create a split pane with output+history in top and command+context+status in bottom
         verticalSplitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+        // Set resize weight to prevent top component from collapsing on initial load
+        verticalSplitPane.setResizeWeight(0.4); // Give 40% of space to top component
         verticalSplitPane.setTopComponent(historyOutputPane);
 
         // Create a panel for everything below the output area
@@ -1049,6 +1051,10 @@ public class Chrome implements AutoCloseable, IConsoleIO {
             int verticalPos = getProject().getVerticalSplitPosition();
             if (verticalPos > 0) {
                 verticalSplitPane.setDividerLocation(verticalPos);
+            } else {
+                // For new projects with no saved position, set a reasonable default
+                // to prevent the top component from collapsing to zero height
+                verticalSplitPane.setDividerLocation(0.4);
             }
 
             // Restore history split pane position


### PR DESCRIPTION
Set a default spliter position so that new opened Projects does not have collapsed top area above instructions