### PR TITLE
Refactor Output Handling to Use Structured Messages

### DIFF
--- a/src/main/java/io/github/jbellis/brokk/Coder.java
+++ b/src/main/java/io/github/jbellis/brokk/Coder.java
@@ -5,10 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.*;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -123,7 +120,7 @@ public class Coder {
             public void onPartialResponse(String token) {
                 ifNotCancelled.accept(() -> {
                     if (echo) {
-                        io.llmOutput(token);
+                        io.llmOutput(token, ChatMessageType.AI);
                         io.hideOutputSpinner();
                     }
                 });
@@ -134,7 +131,7 @@ public class Coder {
                 ifNotCancelled.accept(() -> {
                     io.hideOutputSpinner();
                     if (echo) {
-                        io.llmOutput("\n");
+                        io.llmOutput("\n", ChatMessageType.AI);
                     }
                     atomicResponse.set(response);
                     if (response == null) {

--- a/src/main/java/io/github/jbellis/brokk/ContextFragment.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextFragment.java
@@ -376,9 +376,9 @@ public interface ContextFragment extends Serializable {
     }
 
     final class StringFragment extends VirtualFragment implements OutputFragment {
-        private static final long serialVersionUID = 2L;
-        private final String text;
-        private final String description;
+            private static final long serialVersionUID = 3L;
+            private final String text;
+            private final String description;
         private final String syntaxStyle;
 
         public StringFragment(String text, String description, String syntaxStyle) {
@@ -417,9 +417,9 @@ public interface ContextFragment extends Serializable {
     }
 
     final class SearchFragment extends VirtualFragment implements OutputFragment {
-        private static final long serialVersionUID = 2L;
-        private final String query;
-        private final String explanation;
+            private static final long serialVersionUID = 3L;
+            private final String query;
+            private final String explanation;
         private final Set<CodeUnit> sources;
 
         public SearchFragment(String query, String explanation, Set<CodeUnit> sources) {
@@ -522,8 +522,8 @@ public interface ContextFragment extends Serializable {
     }
 
     final class PasteTextFragment extends PasteFragment implements OutputFragment {
-        private static final long serialVersionUID = 3L;
-        private final String text;
+            private static final long serialVersionUID = 4L;
+            private final String text;
 
         public PasteTextFragment(String text, Future<String> descriptionFuture) {
             super(descriptionFuture);
@@ -789,9 +789,9 @@ public interface ContextFragment extends Serializable {
     }
 
     /** Base class for fragments that represent task history */
-    abstract class TaskHistoryFragment extends VirtualFragment {
-        private static final long serialVersionUID = 3L;
-        protected final List<TaskEntry> history;
+        abstract class TaskHistoryFragment extends VirtualFragment {
+            private static final long serialVersionUID = 4L;
+            protected final List<TaskEntry> history;
 
         public TaskHistoryFragment(List<TaskEntry> history) {
             super();
@@ -841,10 +841,10 @@ public interface ContextFragment extends Serializable {
     }
 
     /** represents the entire Task History */
-    final class ConversationFragment extends TaskHistoryFragment implements OutputFragment {
-        private static final long serialVersionUID = 3L;
-
-        public ConversationFragment(List<TaskEntry> history) {
+        final class ConversationFragment extends TaskHistoryFragment implements OutputFragment {
+            private static final long serialVersionUID = 4L;
+    
+            public ConversationFragment(List<TaskEntry> history) {
             super(history);
         }
 
@@ -860,9 +860,9 @@ public interface ContextFragment extends Serializable {
     }
 
     /** represents a single session's Task History */
-    final class SessionFragment extends TaskHistoryFragment implements OutputFragment {
-        private static final long serialVersionUID = 3L;
-        private final String sessionName;
+        final class SessionFragment extends TaskHistoryFragment implements OutputFragment {
+            private static final long serialVersionUID = 4L;
+            private final String sessionName;
 
         public SessionFragment(List<TaskEntry> history, String sessionName) {
             super(history);

--- a/src/main/java/io/github/jbellis/brokk/ContextManager.java
+++ b/src/main/java/io/github/jbellis/brokk/ContextManager.java
@@ -282,7 +282,8 @@ public class ContextManager implements IContextManager, AutoCloseable {
 
     public Future<?> submitAction(String action, String input, Runnable task) {
         return userActionExecutor.submit(() -> {
-            io.setLlmOutput("# %s\n%s\n\n# %s\n".formatted(action, input, action.equals("Run") ? "Output" : "Response"));
+            var text = "# %s\n%s\n\n# %s\n".formatted(action, input, action.equals("Run") ? "Output" : "Response");
+            io.setLlmOutput(List.of(new UserMessage(text)));
             io.disableHistoryPanel();
 
             try {

--- a/src/main/java/io/github/jbellis/brokk/EditBlock.java
+++ b/src/main/java/io/github/jbellis/brokk/EditBlock.java
@@ -1,5 +1,6 @@
 package io.github.jbellis.brokk;
 
+import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -180,7 +181,7 @@ public class EditBlock {
          } // End of for loop
 
         if (!succeeded.isEmpty()) {
-            io.llmOutput("\n" + succeeded.size() + " SEARCH/REPLACE blocks applied.");
+            io.llmOutput("\n" + succeeded.size() + " SEARCH/REPLACE blocks applied.", ChatMessageType.USER);
         }
         changedFiles.keySet().retainAll(succeeded.values());
         return new EditResult(changedFiles, failed);

--- a/src/main/java/io/github/jbellis/brokk/IConsoleIO.java
+++ b/src/main/java/io/github/jbellis/brokk/IConsoleIO.java
@@ -1,5 +1,7 @@
 package io.github.jbellis.brokk;
 
+import dev.langchain4j.data.message.ChatMessageType;
+
 public interface IConsoleIO {
     void actionOutput(String msg);
 
@@ -12,10 +14,19 @@ public interface IConsoleIO {
 
     void toolErrorRaw(String msg);
 
-    void llmOutput(String token);
+    public enum MessageSubType {
+        BuildError,
+        CommandOutput
+    }
 
+    void llmOutput(String token, ChatMessageType type, MessageSubType messageSubType);
+
+    default void llmOutput(String token, ChatMessageType type) {
+        llmOutput(token, type, null);
+    }
+    
     default void systemOutput(String message) {
-        llmOutput("\n" + message);
+        llmOutput("\n" + message, ChatMessageType.USER);
     }
     
     default void showOutputSpinner(String message) {}

--- a/src/main/java/io/github/jbellis/brokk/Models.java
+++ b/src/main/java/io/github/jbellis/brokk/Models.java
@@ -4,13 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ImageContent;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.TextContent;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.*;
 import dev.langchain4j.model.StreamingResponseHandler;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
@@ -348,6 +342,7 @@ public final class Models {
     public static String getRepr(ChatMessage message) {
         return switch (message) {
             case SystemMessage sm -> sm.text();
+            case CustomMessage cm -> cm.attributes().get("text").toString();
             case AiMessage am -> {
                 var raw = am.text() == null ? "" : am.text();
                 if (!am.hasToolExecutionRequests()) {

--- a/src/main/java/io/github/jbellis/brokk/SessionResult.java
+++ b/src/main/java/io/github/jbellis/brokk/SessionResult.java
@@ -41,7 +41,10 @@ public record SessionResult(String actionDescription,
         this(actionDescription,
              messages,
              originalContents,
-             new Context.ParsedOutput(outputString, new ContextFragment.StringFragment(outputString, "AI Response", SyntaxConstants.SYNTAX_STYLE_MARKDOWN)),
+             new Context.ParsedOutput(outputString,
+                                      new ContextFragment.SessionFragment(
+                                              List.of(new TaskEntry(0, actionDescription, messages, null)),
+                                              actionDescription)),
              stopDetails);
     }
 
@@ -52,31 +55,53 @@ public record SessionResult(String actionDescription,
     public static String getShortDescription(String description, int words) {
         var cleaned = description.trim().replaceAll("[^a-zA-Z0-9\\s]", "");
         return cleaned.split("\\s+").length <= words
-                ? cleaned
-                : String.join(" ", Arrays.asList(cleaned.split("\\s+")).subList(0, words));
+               ? cleaned
+               : String.join(" ", Arrays.asList(cleaned.split("\\s+")).subList(0, words));
     }
 
-    /** Enum representing the reason a CodeAgent session concluded. */
+    /**
+     * Enum representing the reason a CodeAgent session concluded.
+     */
     public enum StopReason {
-        /** The agent successfully completed the goal. */
+        /**
+         * The agent successfully completed the goal.
+         */
         SUCCESS,
-        /** The user interrupted the session. */
+        /**
+         * The user interrupted the session.
+         */
         INTERRUPTED,
-        /** The LLM returned an error after retries. */
+        /**
+         * The LLM returned an error after retries.
+         */
         LLM_ERROR,
-        /** The LLM returned an empty or blank response after retries. */
+        /**
+         * The LLM returned an empty or blank response after retries.
+         */
         EMPTY_RESPONSE,
-        /** The LLM response could not be parsed after retries. */
+        /**
+         * The LLM response could not be parsed after retries.
+         */
         PARSE_ERROR,
-        /** Applying edits failed after retries. */
+        /**
+         * Applying edits failed after retries.
+         */
         APPLY_ERROR,
-        /** Build errors occurred and were not improving after retries. */
+        /**
+         * Build errors occurred and were not improving after retries.
+         */
         BUILD_ERROR,
-        /** The LLM attempted to edit a read-only file. */
+        /**
+         * The LLM attempted to edit a read-only file.
+         */
         READ_ONLY_EDIT,
-        /** the LLM called answer() but did not provide a result */
+        /**
+         * the LLM called answer() but did not provide a result
+         */
         SEARCH_INVALID_ANSWER,
-        /** the LLM determined that it was not possible to answer the query */
+        /**
+         * the LLM determined that it was not possible to answer the query
+         */
         SEARCH_IMPOSSIBLE;
     }
 

--- a/src/main/java/io/github/jbellis/brokk/SessionResult.java
+++ b/src/main/java/io/github/jbellis/brokk/SessionResult.java
@@ -2,6 +2,7 @@ package io.github.jbellis.brokk;
 
 import dev.langchain4j.data.message.ChatMessage;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +41,7 @@ public record SessionResult(String actionDescription,
         this(actionDescription,
              messages,
              originalContents,
-             new Context.ParsedOutput(outputString, new ContextFragment.StringFragment(outputString, "AI Response", ContextFragment.SYNTAX_STYLE_DIFF)),
+             new Context.ParsedOutput(outputString, new ContextFragment.StringFragment(outputString, "AI Response", SyntaxConstants.SYNTAX_STYLE_MARKDOWN)),
              stopDetails);
     }
 

--- a/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
+++ b/src/main/java/io/github/jbellis/brokk/agents/CodeAgent.java
@@ -2,6 +2,7 @@ package io.github.jbellis.brokk.agents;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import io.github.jbellis.brokk.*;
@@ -545,7 +546,7 @@ public class CodeAgent {
           %s
           """.stripIndent().formatted(count, pluralize, failedText, pluralize, pluralize, successfulText);
 
-        io.llmOutput("\n" + failedApplyMessage); // Show the user what we're telling the LLM
+        io.llmOutput("\n" + failedApplyMessage, ChatMessageType.USER); // Show the user what we're telling the LLM
         return failedApplyMessage; // Return the message to be sent to the LLM
     }
 
@@ -577,7 +578,7 @@ public class CodeAgent {
         ```
         %s
         ```
-        """.stripIndent().formatted(result.error(), result.output()));
+        """.stripIndent().formatted(result.error(), result.output()), ChatMessageType.USER, IConsoleIO.MessageSubType.BuildError);
         io.systemOutput("Verification failed (details above)");
         // Add the combined error and output to the history for the next request
         buildErrors.add(result.error() + "\n\n" + result.output());

--- a/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/Chrome.java
@@ -1,5 +1,7 @@
 package io.github.jbellis.brokk.gui;
 
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.Brokk;
 import io.github.jbellis.brokk.Context;
 import io.github.jbellis.brokk.ContextFragment;
@@ -472,12 +474,18 @@ public class Chrome implements AutoCloseable, IConsoleIO {
     }
 
     @Override
-    public void llmOutput(String token) {
-        SwingUtilities.invokeLater(() -> historyOutputPanel.appendLlmOutput(token));
+    public void llmOutput(String token, ChatMessageType type, MessageSubType messageSubType) {
+        // TODO: use messageSubType later on
+        SwingUtilities.invokeLater(() -> historyOutputPanel.appendLlmOutput(token, type));
     }
 
-    public void setLlmOutput(String text) {
-        SwingUtilities.invokeLater(() -> historyOutputPanel.setLlmOutput(text));
+    @Override
+    public void llmOutput(String token, ChatMessageType type) {
+        llmOutput(token, type, null);
+    }
+
+    public void setLlmOutput(List<ChatMessage> newMessages) {
+        SwingUtilities.invokeLater(() -> historyOutputPanel.setLlmOutput(newMessages));
     }
 
     @Override
@@ -603,7 +611,9 @@ public class Chrome implements AutoCloseable, IConsoleIO {
                         // Use MarkdownOutputPanel for Markdown and Diff
                         var markdownPanel = new MarkdownOutputPanel();
                         markdownPanel.updateTheme(themeManager != null && themeManager.isDarkTheme());
-                        markdownPanel.setText(content);
+
+                        // TODO: how to do this?
+                        // markdownPanel.setText(content);
 
                         // Wrap in a scroll pane
                         var scrollPane = new JScrollPane(markdownPanel);

--- a/src/main/java/io/github/jbellis/brokk/gui/ContextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/ContextPanel.java
@@ -291,7 +291,7 @@ public class ContextPanel extends JPanel {
                                 });
                                 contextMenu.add(compressHistoryItem);
                                 // Only enable if uncompressed entries exist
-                                var uncompressedExists = cf.getHistory().stream().anyMatch(entry -> !entry.isCompressed());
+                                var uncompressedExists = cf.getMessages().stream().anyMatch(entry -> !entry.isCompressed());
                                 compressHistoryItem.setEnabled(uncompressedExists);
                             }
                         }

--- a/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -1,8 +1,11 @@
 package io.github.jbellis.brokk.gui;
 
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.Context;
 import io.github.jbellis.brokk.ContextManager;
 import io.github.jbellis.brokk.Project;
+import io.github.jbellis.brokk.TaskEntry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,6 +18,7 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.List;
 
 /**
  * A component that combines the context history panel with the output panel using BorderLayout.
@@ -421,9 +425,9 @@ public class HistoryOutputPanel extends JPanel {
         openWindowButton.setMnemonic(KeyEvent.VK_W);
         openWindowButton.setToolTipText("Open the output in a new window");
         openWindowButton.addActionListener(e -> {
-            String text = llmStreamArea.getText();
-            if (!text.isBlank()) {
-                new OutputWindow(this, text, chrome.themeManager != null && chrome.themeManager.isDarkTheme());
+            var messages = llmStreamArea.getRawMessages();
+            if (messages != null && !messages.isEmpty()) { 
+                new OutputWindow(this, messages, chrome.themeManager != null && chrome.themeManager.isDarkTheme());
             }
         });
         // Set minimum size
@@ -443,13 +447,14 @@ public class HistoryOutputPanel extends JPanel {
         return llmStreamArea.getText();
     }
 
-    /**
-     * Sets the text in the LLM output area
-     */
-    public void setLlmOutput(String text) {
-        llmStreamArea.setText(text);
+    public void setLlmOutput(TaskEntry taskEntry) {
+        llmStreamArea.setText(taskEntry);
     }
 
+    public void setLlmOutput(List<ChatMessage> newMessages) {
+        llmStreamArea.setText(newMessages);
+    }
+    
     /**
      * Sets the text in the LLM output area
      */
@@ -460,7 +465,8 @@ public class HistoryOutputPanel extends JPanel {
             return;
         }
 
-        setLlmOutput(text);
+        // TODO: show text or fragment (ConversationFragment)
+        // setLlmOutput(text);
         // Scroll to the top
         SwingUtilities.invokeLater(() -> {
             llmScrollPane.getVerticalScrollBar().setValue(0);
@@ -470,8 +476,8 @@ public class HistoryOutputPanel extends JPanel {
     /**
      * Appends text to the LLM output area
      */
-    public void appendLlmOutput(String text) {
-        llmStreamArea.append(text);
+    public void appendLlmOutput(String text, ChatMessageType type) {
+        llmStreamArea.append(text, type);
     }
 
     /**
@@ -527,10 +533,10 @@ public class HistoryOutputPanel extends JPanel {
          * Creates a new output window with the given text content
          *
          * @param parentPanel The parent HistoryOutputPanel
-         * @param text The markdown text to display
+         * @param messages The messages (ai, user, ...) to display
          * @param isDark Whether to use dark theme
          */
-        public OutputWindow(HistoryOutputPanel parentPanel, String text, boolean isDark) {
+        public OutputWindow(HistoryOutputPanel parentPanel, List<ChatMessage> messages, boolean isDark) {
             super("Output"); // Call superclass constructor first
             this.parentPanel = parentPanel;
             this.project = parentPanel.contextManager.getProject(); // Get project reference
@@ -539,7 +545,7 @@ public class HistoryOutputPanel extends JPanel {
             // Create markdown panel with the text
             var outputPanel = new MarkdownOutputPanel();
             outputPanel.updateTheme(isDark);
-            outputPanel.setText(text);
+            outputPanel.setText(messages);
 
             // Add to a scroll pane
             var scrollPane = new JScrollPane(outputPanel);

--- a/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/HistoryOutputPanel.java
@@ -2,10 +2,7 @@ package io.github.jbellis.brokk.gui;
 
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ChatMessageType;
-import io.github.jbellis.brokk.Context;
-import io.github.jbellis.brokk.ContextManager;
-import io.github.jbellis.brokk.Project;
-import io.github.jbellis.brokk.TaskEntry;
+import io.github.jbellis.brokk.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -19,6 +16,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A component that combines the context history panel with the output panel using BorderLayout.
@@ -458,15 +456,17 @@ public class HistoryOutputPanel extends JPanel {
     /**
      * Sets the text in the LLM output area
      */
-    public void resetLlmOutput(String text) {
+    public void resetLlmOutput(TaskEntry taskEntry) {
         // this is called by the context selection listener, but when we just finished streaming a response
         // we don't want scroll-to-top behavior
-        if (llmStreamArea.getText().equals(text)) {
+        var newText = taskEntry.log().stream()
+                .map(Models::getRepr)
+                .collect(Collectors.joining("\n\n"));
+        if (llmStreamArea.getText().equals(newText)) {
             return;
         }
 
-        // TODO: show text or fragment (ConversationFragment)
-        // setLlmOutput(text);
+        setLlmOutput(taskEntry);
         // Scroll to the top
         SwingUtilities.invokeLater(() -> {
             llmScrollPane.getVerticalScrollBar().setValue(0);
@@ -519,9 +519,9 @@ public class HistoryOutputPanel extends JPanel {
         return llmScrollPane;
     }
 
-    // setCommandResultText removed
-
-    // clearCommandResultText removed
+    public void clearLlmOutput() {
+        llmStreamArea.clear();
+    }
 
     /**
      * Inner class representing a detached window for viewing output text

--- a/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/InstructionsPanel.java
@@ -545,7 +545,8 @@ public class InstructionsPanel extends JPanel {
         var contextManager = chrome.getContextManager();
         var result = Environment.instance.captureShellCommand(input, contextManager.getRoot());
         String output = result.output().isBlank() ? "[operation completed with no output]" : result.output();
-        chrome.llmOutput("\n```\n" + output + "\n```", ChatMessageType.USER, IConsoleIO.MessageSubType.CommandOutput);
+        var wrappedPutput = "\n```\n" + output + "\n```";
+        chrome.llmOutput(wrappedPutput, ChatMessageType.USER, IConsoleIO.MessageSubType.CommandOutput);
 
         var llmOutputText = chrome.getLlmOutputText();
         if (llmOutputText == null) {
@@ -555,7 +556,7 @@ public class InstructionsPanel extends JPanel {
 
         // Add to context history with the output text
         contextManager.pushContext(ctx -> {
-            var runFrag = new ContextFragment.StringFragment(output, "Run " + input, SyntaxConstants.SYNTAX_STYLE_MARKDOWN);
+            var runFrag = new ContextFragment.StringFragment(wrappedPutput, "Run " + input, SyntaxConstants.SYNTAX_STYLE_MARKDOWN);
             var parsed = new ParsedOutput(llmOutputText, runFrag);
             return ctx.withParsedOutput(parsed, CompletableFuture.completedFuture("Run " + input));
         });

--- a/src/main/java/io/github/jbellis/brokk/gui/MarkdownOutputPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/MarkdownOutputPanel.java
@@ -413,12 +413,12 @@ class MarkdownOutputPanel extends JPanel implements Scrollable {
                             blocksPanel.add(textPanel);
                         }
                     }
-                    blocksPanel.setBorder(BorderFactory.createLineBorder(Color.yellow, 10));
+                    blocksPanel.setBorder(BorderFactory.createLineBorder(Color.yellow, 2));
                     messagePanel.add(blocksPanel);
                 } else {
                     // No edit blocks, render as markdown
                     var contentPanel = renderMarkdownContent(content);
-                    contentPanel.setBorder(BorderFactory.createLineBorder(Color.yellow, 10));
+                    contentPanel.setBorder(BorderFactory.createLineBorder(Color.yellow, 2));
                     messagePanel.add(contentPanel);
                 }
             }
@@ -428,7 +428,7 @@ class MarkdownOutputPanel extends JPanel implements Scrollable {
                 userPanel.setLayout(new BoxLayout(userPanel, BoxLayout.Y_AXIS));
                 userPanel.setBackground(isDarkTheme ? new Color(60, 60, 60) : new Color(245, 245, 245));
                 // userPanel.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-                userPanel.setBorder(BorderFactory.createLineBorder(Color.red, 10));
+                userPanel.setBorder(BorderFactory.createLineBorder(Color.red, 2));
                 userPanel.setAlignmentX(LEFT_ALIGNMENT);
                 var textPane = renderMarkdownContent(Models.getRepr(message));
                 textPane.setForeground(isDarkTheme ? new Color(220, 220, 220) : new Color(30, 30, 30));
@@ -442,7 +442,7 @@ class MarkdownOutputPanel extends JPanel implements Scrollable {
                 customPanel.setLayout(new BoxLayout(customPanel, BoxLayout.Y_AXIS));
                 customPanel.setBackground(isDarkTheme ? new Color(60, 60, 60) : new Color(245, 245, 245));
                 // customPanel.setBorder(BorderFactory.createEmptyBorder(5, 10, 5, 10));
-                customPanel.setBorder(BorderFactory.createLineBorder(Color.blue, 10));
+                customPanel.setBorder(BorderFactory.createLineBorder(Color.blue, 2));
                 customPanel.setAlignmentX(LEFT_ALIGNMENT);
                 var textPane = renderMarkdownContent(Models.getRepr(message));
                 textPane.setForeground(isDarkTheme ? new Color(220, 220, 220) : new Color(30, 30, 30));

--- a/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
+++ b/src/main/java/io/github/jbellis/brokk/gui/dialogs/PreviewTextPanel.java
@@ -1,6 +1,7 @@
 package io.github.jbellis.brokk.gui.dialogs;
 
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.agents.CodeAgent;
 import io.github.jbellis.brokk.ContextFragment;
 import io.github.jbellis.brokk.ContextManager;
@@ -644,7 +645,7 @@ public class PreviewTextPanel extends JPanel {
             }
 
             @Override
-            public void llmOutput(String token) {
+            public void llmOutput(String token, ChatMessageType type, MessageSubType messageSubType) {
                 appendSystemMessage(token);
             }
 

--- a/src/test/java/io/github/jbellis/brokk/CoderTest.java
+++ b/src/test/java/io/github/jbellis/brokk/CoderTest.java
@@ -226,10 +226,11 @@ public class CoderTest {
         
         // Verify the think tool's description and parameter
         var thinkTool = allTools.getFirst();
-        assertTrue(thinkTool.description().contains("Thinking step by step"), 
-                  "Think tool should have the correct description");
-        assertEquals(1, thinkTool.parameters().properties().size(), 
-                    "Think tool should have exactly one parameter");
+        // Check if the description contains the phrase "step by step".
+        assertTrue(thinkTool.description().contains("step by step"),
+                  "Think tool description should mention 'step by step'. Actual: " + thinkTool.description());
+        assertEquals(1, thinkTool.parameters().properties().size(),
+                        "Think tool should have exactly one parameter");
         assertTrue(thinkTool.parameters().properties().containsKey("reasoning"), 
                   "Think tool should have a 'reasoning' parameter");
     }

--- a/src/test/java/io/github/jbellis/brokk/CoderTest.java
+++ b/src/test/java/io/github/jbellis/brokk/CoderTest.java
@@ -3,10 +3,7 @@ package io.github.jbellis.brokk;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agent.tool.ToolSpecifications;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.*;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import org.junit.jupiter.api.Assumptions;
@@ -37,7 +34,7 @@ public class CoderTest {
         @Override public void toolErrorRaw(String msg) {
             System.out.println("Tool error: " + msg);
         }
-        @Override public void llmOutput(String token) {}
+        @Override public void llmOutput(String token, ChatMessageType type, MessageSubType messageSubType) {}
         @Override public void systemOutput(String message) {}
         @Override public void showOutputSpinner(String message) {}
         @Override public void hideOutputSpinner() {}

--- a/src/test/java/io/github/jbellis/brokk/EditBlockTest.java
+++ b/src/test/java/io/github/jbellis/brokk/EditBlockTest.java
@@ -1,5 +1,6 @@
 package io.github.jbellis.brokk;
 
+import dev.langchain4j.data.message.ChatMessageType;
 import io.github.jbellis.brokk.analyzer.ProjectFile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,7 +53,7 @@ class EditBlockTest {
         }
 
         @Override
-        public void llmOutput(String token) {
+        public void llmOutput(String token, ChatMessageType type, MessageSubType messageSubType) {
             // not needed for these tests
         }
 


### PR DESCRIPTION
## Refactor Output Handling to Use Structured Messages

This PR introduces a significant refactoring of how output (LLM responses, system messages, command results, etc.) is handled and displayed throughout the application.

**Core Change:**

The primary change is moving away from representing and passing output as raw `String` objects. Instead, the system now uses structured `dev.langchain4j.data.message.ChatMessage` objects (including `UserMessage`, `AiMessage`, `CustomMessage`) and `TaskEntry` lists.

**Key Impacts & Benefits:**

*   **Richer Representation:** Using `ChatMessage` allows the system to understand the *type* of output (AI, User, System, Tool, Build Error, etc.), not just the text content.
*   **Improved UI Rendering:**
    *   The `MarkdownOutputPanel` has been rewritten to render a sequence of distinct message components instead of a single text buffer. This prevents flickering during streaming and enables specific styling for different message types.
    *   Context fragments representing output/history (like `ConversationFragment`, `SessionFragment`, `SearchFragment`) now provide their content as a list of messages (`TaskEntry`), allowing previews (`openFragmentPreview`) to render them as structured conversations.
*   **Foundation for Future Enhancements:** This structured approach makes it easier to implement features like filtering message types, applying distinct visual themes, and improving the handling of complex outputs (e.g., edit blocks mixed with markdown).

**Areas Affected:**

This change touches many parts of the codebase involved in generating or displaying output, including:
*   `IConsoleIO` interface
*   `MarkdownOutputPanel`, `HistoryOutputPanel`, `Chrome` (GUI components)
*   `ContextFragment` (new `OutputFragment`, `SessionFragment`, modified existing fragments)
*   Agents (`Coder`, `CodeAgent`) and `ContextManager`
*   `SessionResult`

## Temporary Styling:
- red -> User Messages
- yellow -> AI Messages
- blue -> Common Messages (no user nor ai) 

![image](https://github.com/user-attachments/assets/bc337708-d515-4bd4-8f89-fa9f7dd5ba29)
